### PR TITLE
Moving some of reference config towards reusable modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .terraform*
 *.tfstate*
 .idea/
+.creds

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 # PagerDuty Populate Dev Account
-This project provides an easy way to populate a [PagerDuty Developer Account](https://developer.pagerduty.com/sign-up/) with realistic data. The project uses [Terraform](https://www.terraform.io/) and the [PagerDuty Provider](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs) for Terraform to create and manage the various objects in PagerDuty. To learn more about [Terraform](https://www.terraform.io/) head over to the product page at [HashiCorp](https://www.hashicorp.com/).
-
-> *Additional Terraform code samples can be found at [PagerDuty-Samples/terraform-examples](https://github.com/PagerDuty-Samples/terraform-examples)*.
+This project provides an easy way to populate a [PagerDuty Developer Account](https://developer.pagerduty.com/sign-up/) with real data. The project uses [Terraform](https://www.terraform.io/) and the [PagerDuty Provider](https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs) for Terraform to create and manage the various objects in PagerDuty. To learn more about [Terraform](https://www.terraform.io/) head over to the product page at [HashiCorp](https://www.hashicorp.com/).
 
 To learn more about using Terraform with PagerDuty, checkout [The How and Why of Using Terraform with PagerDuty](https://www.pagerduty.com/eng/how-why-terraform/).
 
 ## How to Use
 - Sign up for a [Developer Account](https://developer.pagerduty.com/sign-up/). This account will provide you with a sandbox that will allow you to build and modify things in a PagerDuty account without messing with production data.
 - [Generate a PagerDuty REST API key](https://support.pagerduty.com/docs/generating-api-keys).
-- Using that key, set the value of of the `provider "pagerduty"` token in `main.tf`.
+- Using that key, set the value of of the `provider "pagerduty"` token in `providers.tf`.
 
 ```
 provider "pagerduty" {
     token = "your_api_key_value"
 }
 ```
-- In this directory, run a `terraform init` in the command line.
+- In the root directory, run a `terraform init` in the command line.
 - Run `terraform plan` to see what changes this file will implement. 
 - If everything looks good in your plan, run `terraform apply`. This will show you the plan again and then ask you to confirm whether you want to perform the proposed actions. Type `yes`. 
 
-When the process is complete your PagerDuty instance should now have all the resources listed below created. 
+When the process is complete your PagerDuty instance should now have all the resources listed below created.
 
-## Resources created
-The code here will create the following resources in PagerDuty.
+## Data and Resources
+
+The code here will create the following resources in PagerDuty as populated by a file
 
 - **Users**
 - **Teams**
@@ -30,9 +29,9 @@ The code here will create the following resources in PagerDuty.
 - **Escalation Policy**
 - **Schedule**
 - **Services**
+- **Service Dependency**
 - **Service Integrations**
 - **Business Service**
-- **Service Dependency**
 - **Event Orchestration**
 
 ## Questions

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,13 @@
+# User Modules to make USERS
+
+module "user1" {
+  source = "modules/users"
+  email = "bart@foo.test"
+  name = "Bart Simpson"
+  job_title = "Rascal"
+}
 
 
-# USERS
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
 resource "pagerduty_user" "bart" {
   email       = "bart@foo.test"
   name        = "Bart Simpson"

--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,21 @@
 # User Modules to make USERS
 
 module "user1" {
-  source = "modules/users"
+  source = "./modules/users"
   email = "bart@foo.test"
   name = "Bart Simpson"
   job_title = "Rascal"
+
 }
 
 
-resource "pagerduty_user" "bart" {
-  email       = "bart@foo.test"
-  name        = "Bart Simpson"
-  role        = "limited_user"
-  description = "Spikey-haired boy"
-  job_title   = "Rascal"
-}
+# resource "pagerduty_user" "bart" {
+#   email       = "bart@foo.test"
+#   name        = "Bart Simpson"
+#   role        = "limited_user"
+#   description = "Spikey-haired boy"
+#   job_title   = "Rascal"
+# }
 
 # # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
 # resource "pagerduty_user" "lisa" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,4 @@
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs
-provider "pagerduty" {
-  token = "your_api_access_token"
-}
+
 
 # USERS
 # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
@@ -13,262 +10,262 @@ resource "pagerduty_user" "bart" {
   job_title   = "Rascal"
 }
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
-resource "pagerduty_user" "lisa" {
-  email       = "lisa@foo.test"
-  name        = "Lisa Simpson"
-  role        = "admin"
-  description = "The brains"
-  job_title   = "Supreme Thinker"
-}
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
+# resource "pagerduty_user" "lisa" {
+#   email       = "lisa@foo.test"
+#   name        = "Lisa Simpson"
+#   role        = "admin"
+#   description = "The brains"
+#   job_title   = "Supreme Thinker"
+# }
 
-# TEAMS
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/team
-resource "pagerduty_team" "simpson" {
-  name        = "Simpson"
-  description = "Team of Simpsons"
-}
-
-
-# TEAM MEMBERSHIP
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/team_membership
-resource "pagerduty_team_membership" "lisa" {
-  user_id = pagerduty_user.lisa.id
-  team_id = pagerduty_team.simpson.id
-  role    = "manager"
-}
-
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/team_membership
-resource "pagerduty_team_membership" "bart" {
-  user_id = pagerduty_user.bart.id
-  team_id = pagerduty_team.simpson.id
-  role    = "responder"
-}
+# # TEAMS
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/team
+# resource "pagerduty_team" "simpson" {
+#   name        = "Simpson"
+#   description = "Team of Simpsons"
+# }
 
 
-# escalation policy
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/escalation_policy
-resource "pagerduty_escalation_policy" "checkout_service" {
-  name      = "Checkout Service Escalation Policy"
-  num_loops = 3
+# # TEAM MEMBERSHIP
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/team_membership
+# resource "pagerduty_team_membership" "lisa" {
+#   user_id = pagerduty_user.lisa.id
+#   team_id = pagerduty_team.simpson.id
+#   role    = "manager"
+# }
 
-  rule {
-    escalation_delay_in_minutes = 30
-    target {
-      type = "schedule_reference"
-      id   = pagerduty_schedule.checkout_service.id
-    }
-  }
-}
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/team_membership
+# resource "pagerduty_team_membership" "bart" {
+#   user_id = pagerduty_user.bart.id
+#   team_id = pagerduty_team.simpson.id
+#   role    = "responder"
+# }
 
-# SCHEDULE
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/schedule
-resource "pagerduty_schedule" "checkout_service" {
-  name      = "Checkout Service Schedule"
-  time_zone = "America/Los_Angeles"
 
-  layer {
-    name                         = "Night Shift"
-    start                        = "2022-10-27T20:00:00-08:00"
-    rotation_virtual_start       = "2022-10-27T17:00:00-08:00"
-    rotation_turn_length_seconds = 86400
+# # escalation policy
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/escalation_policy
+# resource "pagerduty_escalation_policy" "checkout_service" {
+#   name      = "Checkout Service Escalation Policy"
+#   num_loops = 3
 
-    users = [
-      pagerduty_user.lisa.id,
-      pagerduty_user.bart.id
-    ]
+#   rule {
+#     escalation_delay_in_minutes = 30
+#     target {
+#       type = "schedule_reference"
+#       id   = pagerduty_schedule.checkout_service.id
+#     }
+#   }
+# }
 
-    restriction {
-      type              = "daily_restriction"
-      start_time_of_day = "07:00:00"
-      duration_seconds  = 54000
-    }
-  }
-}
+# # SCHEDULE
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/schedule
+# resource "pagerduty_schedule" "checkout_service" {
+#   name      = "Checkout Service Schedule"
+#   time_zone = "America/Los_Angeles"
 
-# SERVICES
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service
-resource "pagerduty_service" "api" {
-  name              = "Checkout API"
-  escalation_policy = pagerduty_escalation_policy.checkout_service.id
-  alert_creation    = "create_alerts_and_incidents"
-}
+#   layer {
+#     name                         = "Night Shift"
+#     start                        = "2022-10-27T20:00:00-08:00"
+#     rotation_virtual_start       = "2022-10-27T17:00:00-08:00"
+#     rotation_turn_length_seconds = 86400
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service
-resource "pagerduty_service" "db" {
-  name              = "Checkout DB"
-  escalation_policy = pagerduty_escalation_policy.checkout_service.id
-  alert_creation    = "create_alerts_and_incidents"
-}
+#     users = [
+#       pagerduty_user.lisa.id,
+#       pagerduty_user.bart.id
+#     ]
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service
-resource "pagerduty_service" "unrouted" {
-  name              = "Checkout Unrouted"
-  escalation_policy = pagerduty_escalation_policy.checkout_service.id
-  alert_creation    = "create_alerts_and_incidents"
+#     restriction {
+#       type              = "daily_restriction"
+#       start_time_of_day = "07:00:00"
+#       duration_seconds  = 54000
+#     }
+#   }
+# }
 
-  auto_pause_notifications_parameters {
-    enabled = true
-    timeout = 900
-  }
-}
+# # SERVICES
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service
+# resource "pagerduty_service" "api" {
+#   name              = "Checkout API"
+#   escalation_policy = pagerduty_escalation_policy.checkout_service.id
+#   alert_creation    = "create_alerts_and_incidents"
+# }
 
-# SERVICE INTEGRATION
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/vendor
-data "pagerduty_vendor" "cloudwatch" {
-  name = "Cloudwatch"
-}
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service
+# resource "pagerduty_service" "db" {
+#   name              = "Checkout DB"
+#   escalation_policy = pagerduty_escalation_policy.checkout_service.id
+#   alert_creation    = "create_alerts_and_incidents"
+# }
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration
-resource "pagerduty_service_integration" "cloudwatch" {
-  name    = data.pagerduty_vendor.cloudwatch.name
-  service = pagerduty_service.api.id
-  vendor  = data.pagerduty_vendor.cloudwatch.id
-}
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service
+# resource "pagerduty_service" "unrouted" {
+#   name              = "Checkout Unrouted"
+#   escalation_policy = pagerduty_escalation_policy.checkout_service.id
+#   alert_creation    = "create_alerts_and_incidents"
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/vendor
-data "pagerduty_vendor" "datadog" {
-  name = "Datadog"
-}
+#   auto_pause_notifications_parameters {
+#     enabled = true
+#     timeout = 900
+#   }
+# }
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration
-resource "pagerduty_service_integration" "datadog" {
-  name    = data.pagerduty_vendor.datadog.name
-  service = pagerduty_service.api.id
-  vendor  = data.pagerduty_vendor.datadog.id
-}
+# # SERVICE INTEGRATION
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/vendor
+# data "pagerduty_vendor" "cloudwatch" {
+#   name = "Cloudwatch"
+# }
 
-# BUSINESS SERVICE
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/business_service
-resource "pagerduty_business_service" "api_business" {
-  name = "API Business"
-}
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration
+# resource "pagerduty_service_integration" "cloudwatch" {
+#   name    = data.pagerduty_vendor.cloudwatch.name
+#   service = pagerduty_service.api.id
+#   vendor  = data.pagerduty_vendor.cloudwatch.id
+# }
 
-# SERVICE DEPENDENCY
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency
-resource "pagerduty_service_dependency" "api_service_dependency" {
-  dependency {
-    dependent_service {
-      id   = pagerduty_business_service.api_business.id
-      type = "business_service"
-    }
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/data-sources/vendor
+# data "pagerduty_vendor" "datadog" {
+#   name = "Datadog"
+# }
 
-    supporting_service {
-      id   = pagerduty_service.api.id
-      type = "service"
-    }
-  }
-}
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_integration
+# resource "pagerduty_service_integration" "datadog" {
+#   name    = data.pagerduty_vendor.datadog.name
+#   service = pagerduty_service.api.id
+#   vendor  = data.pagerduty_vendor.datadog.id
+# }
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency
-resource "pagerduty_service_dependency" "api_db_service_dependency" {
-  dependency {
-    dependent_service {
-      id   = pagerduty_business_service.api_business.id
-      type = "business_service"
-    }
+# # BUSINESS SERVICE
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/business_service
+# resource "pagerduty_business_service" "api_business" {
+#   name = "API Business"
+# }
 
-    supporting_service {
-      id   = pagerduty_service.db.id
-      type = "service"
-    }
-  }
-}
+# # SERVICE DEPENDENCY
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency
+# resource "pagerduty_service_dependency" "api_service_dependency" {
+#   dependency {
+#     dependent_service {
+#       id   = pagerduty_business_service.api_business.id
+#       type = "business_service"
+#     }
 
-# EVENT ORCHESTRATION
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/event_orchestration
-resource "pagerduty_event_orchestration" "health_check" {
-  name = "Health Check Orchestration"
-  team = pagerduty_team.simpson.id
-}
+#     supporting_service {
+#       id   = pagerduty_service.api.id
+#       type = "service"
+#     }
+#   }
+# }
 
-# EVENT ORCHESTRATION ROUTER
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/event_orchestration_router
-resource "pagerduty_event_orchestration_router" "health_check" {
-  event_orchestration = pagerduty_event_orchestration.health_check.id
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/service_dependency
+# resource "pagerduty_service_dependency" "api_db_service_dependency" {
+#   dependency {
+#     dependent_service {
+#       id   = pagerduty_business_service.api_business.id
+#       type = "business_service"
+#     }
 
-  set {
-    id = "start"
+#     supporting_service {
+#       id   = pagerduty_service.db.id
+#       type = "service"
+#     }
+#   }
+# }
 
-    rule {
-      label = "API Failed Health Check--Route to API Service"
+# # EVENT ORCHESTRATION
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/event_orchestration
+# resource "pagerduty_event_orchestration" "health_check" {
+#   name = "Health Check Orchestration"
+#   team = pagerduty_team.simpson.id
+# }
 
-      condition {
-        expression = "event.summary matches part 'API Health Check violated API Request Failure' or event.summary matches part 'Request Response Time is High for prod'"
-      }
+# # EVENT ORCHESTRATION ROUTER
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/event_orchestration_router
+# resource "pagerduty_event_orchestration_router" "health_check" {
+#   event_orchestration = pagerduty_event_orchestration.health_check.id
 
-      actions {
-        route_to = pagerduty_service.api.id
-      }
-    }
+#   set {
+#     id = "start"
 
-    rule {
-      label = "DB Failed Health Check--Route to DB Service"
+#     rule {
+#       label = "API Failed Health Check--Route to API Service"
 
-      condition {
-        expression = "event.summary matches part 'Error connecting to MySQL' or event.summary matches part 'mysql_long_running_query'"
-      }
+#       condition {
+#         expression = "event.summary matches part 'API Health Check violated API Request Failure' or event.summary matches part 'Request Response Time is High for prod'"
+#       }
 
-      actions {
-        route_to = pagerduty_service.db.id
-      }
-    }
-  }
+#       actions {
+#         route_to = pagerduty_service.api.id
+#       }
+#     }
 
-  catch_all {
-    actions {
-      route_to = pagerduty_service.unrouted.id
-    }
-  }
-}
+#     rule {
+#       label = "DB Failed Health Check--Route to DB Service"
 
-# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/event_orchestration_service
-resource "pagerduty_event_orchestration_service" "api" {
-  service = pagerduty_service.api.id
+#       condition {
+#         expression = "event.summary matches part 'Error connecting to MySQL' or event.summary matches part 'mysql_long_running_query'"
+#       }
 
-  set {
-    id = "start"
+#       actions {
+#         route_to = pagerduty_service.db.id
+#       }
+#     }
+#   }
 
-    rule {
-      label = "Suppress API Health Check Failure"
+#   catch_all {
+#     actions {
+#       route_to = pagerduty_service.unrouted.id
+#     }
+#   }
+# }
 
-      condition {
-        expression = "event.summary matches part 'API Health Check violated API Request Failure'"
-      }
+# # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/event_orchestration_service
+# resource "pagerduty_event_orchestration_service" "api" {
+#   service = pagerduty_service.api.id
 
-      actions {
-        suspend = 600
-      }
-    }
+#   set {
+#     id = "start"
 
-    rule {
-      label = "Annotate API"
+#     rule {
+#       label = "Suppress API Health Check Failure"
 
-      condition {
-        expression = "event.summary matches part 'Request Response Time is High for prod'"
-      }
+#       condition {
+#         expression = "event.summary matches part 'API Health Check violated API Request Failure'"
+#       }
 
-      actions {
-        annotate = "This is a great note"
-      }
-    }
+#       actions {
+#         suspend = 600
+#       }
+#     }
 
-    rule {
-      label = "Slow DB Query Sev to Info"
+#     rule {
+#       label = "Annotate API"
 
-      condition {
-        expression = "event.summary matches part 'mysql_long_running_query'"
-      }
+#       condition {
+#         expression = "event.summary matches part 'Request Response Time is High for prod'"
+#       }
 
-      actions {
-        severity = "info"
-      }
-    }
-  }
+#       actions {
+#         annotate = "This is a great note"
+#       }
+#     }
 
-  catch_all {
-    actions {
+#     rule {
+#       label = "Slow DB Query Sev to Info"
 
-    }
-  }
-}
+#       condition {
+#         expression = "event.summary matches part 'mysql_long_running_query'"
+#       }
+
+#       actions {
+#         severity = "info"
+#       }
+#     }
+#   }
+
+#   catch_all {
+#     actions {
+
+#     }
+#   }
+# }

--- a/modules/schedules/README.md
+++ b/modules/schedules/README.md
@@ -6,14 +6,29 @@ This opionated module is used for building a pagerduty schedule
 
 This module takes one PagerDuty provider
 
+### to-do's
+Make the layers and restrictions for_each able
+
 ### Example
 
 
 ```terraform
-module "user1" {
-  source = "./modules/users"
-  email = "bart@foo.test"
-  name = "Bart Simpson"
-  job_title = "Rascal"
+module "schedule1" {
+  source = "./modules/schedules"
+  name = "Checkout Service Schedule"
+  time_zone = "America/Los_Angeles"
+  layers = {
+    name                         = "Night Shift"
+    start                        = "2022-10-27T20:00:00-08:00"
+    rotation_virtual_start       = "2022-10-27T17:00:00-08:00"
+    rotation_turn_length_seconds = 86400
+    users = [module.user1.pager_duty_id, module.user2.pager_duty_id],
+    teams = [pagerduty_team.simpson.id]
+     restriction = {
+      type              = "daily_restriction"
+      start_time_of_day = "07:00:00"
+      duration_seconds  = 54000
+    }
+  }
 }
 ```

--- a/modules/schedules/README.md
+++ b/modules/schedules/README.md
@@ -1,9 +1,6 @@
 ## PagerDuty User
-This opionated module is used for building a user, it makes sure that a timezone is set to GMT if appropriate, and 
+This opionated module is used for building a pagerduty schedule
 
-Specifically, it:
-
-* Creates a user based on data passed
 
 ### Providers
 

--- a/modules/schedules/main.tf
+++ b/modules/schedules/main.tf
@@ -1,0 +1,45 @@
+# USERS
+# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
+# as rendered our terraform would look like this however we are doing it the dynamic way
+# resource "pagerduty_schedule" "checkout_service" {
+#   name      = "Checkout Service Schedule"
+#   time_zone = "America/Los_Angeles"
+
+#   layer {
+#     name                         = "Night Shift"
+#     start                        = "2022-10-27T20:00:00-08:00"
+#     rotation_virtual_start       = "2022-10-27T17:00:00-08:00"
+#     rotation_turn_length_seconds = 86400
+
+#     users = [
+#       pagerduty_user.lisa.id,
+#       pagerduty_user.bart.id
+#     ]
+
+#     restriction {
+#       type              = "daily_restriction"
+#       start_time_of_day = "07:00:00"
+#       duration_seconds  = 54000
+#     }
+#   }
+# }
+
+resource "pagerduty_schedule" "checkout_service" {
+  name      = var.name
+  time_zone = var.time_zone
+
+  layer {
+    name                         = var.layers.name
+    start                        = var.layers.start
+    rotation_virtual_start       = var.layers.rotation_virtual_start
+    rotation_turn_length_seconds = var.layers.rotation_turn_length_seconds
+
+    users = var.layers.users
+    restriction {
+    type                =  var.layers.restriction.type
+    start_time_of_day   =  var.layers.restriction.start_time_of_day
+    duration_seconds    =  var.layers.restriction.duration_seconds
+        }
+  }
+
+}

--- a/modules/schedules/main.tf
+++ b/modules/schedules/main.tf
@@ -24,7 +24,7 @@
 #   }
 # }
 
-resource "pagerduty_schedule" "checkout_service" {
+resource "pagerduty_schedule" "generic_schedule" {
   name      = var.name
   time_zone = var.time_zone
 

--- a/modules/schedules/outputs.tf
+++ b/modules/schedules/outputs.tf
@@ -1,0 +1,3 @@
+# output "pager_duty_id" {
+#   value = pagerduty_user.user.id
+# }

--- a/modules/schedules/outputs.tf
+++ b/modules/schedules/outputs.tf
@@ -1,3 +1,6 @@
-# output "pager_duty_id" {
-#   value = pagerduty_user.user.id
-# }
+output "pager_duty_id" {
+   value = pagerduty_schedule.generic_schedule.id
+}
+output "final_schedule" {
+   value = pagerduty_schedule.generic_schedule.final_schedule
+}

--- a/modules/schedules/providers.tf
+++ b/modules/schedules/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    # see https://registry.terraform.io/providers/PagerDuty/pagerduty/2.7.0
+    pagerduty = {
+      source  = "pagerduty/pagerduty"
+      version = "2.11.2"
+    }
+  }
+}

--- a/modules/schedules/variables.tf
+++ b/modules/schedules/variables.tf
@@ -1,0 +1,29 @@
+#https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+variable "time_zone" {
+  type        = string
+  description = "Timezone for the Schedule"
+  default = "America/New_York"
+}
+
+variable "name" {
+  type        = string
+  description = "PagerDuty Schedule Name"
+}
+
+#defaults to limited_users, can be overwritten
+variable "layers" {
+    type = object({
+        name  = string,
+        start = string,
+        rotation_virtual_start = string,
+        rotation_turn_length_seconds = number,
+        users = list(string),
+        teams = list(string),
+        restriction = object({
+          type  = string,
+          start_time_of_day = string,
+          duration_seconds = number
+        })
+    })
+}
+

--- a/modules/users/README.md
+++ b/modules/users/README.md
@@ -1,0 +1,30 @@
+## PagerDuty User
+This opionated module is used for building a user, it makes sure that a timezone is set to GMT if appropriate, and 
+
+Specifically, it:
+
+* Creates a user based on data passed
+
+### Providers
+
+This module takes one PagerDuty provider
+
+### Example
+
+
+```terraform
+module "user1" {
+  source = "../modules/user
+  env    = "production"
+  
+  first_cidr_blocks  = [module.pd-vpc-usw2.cidr_block]
+  second_cidr_blocks = [module.pd-vpc-euc1.cidr_block]
+  first_tgw_id       = module.tgw-usw2.tgw_id
+  second_tgw_id      = module.tgw-euc1.tgw_id
+
+  providers = {
+    aws.nw-first  = aws.nw-usw2
+    aws.nw-second = aws.nw-euc1
+  }
+}
+```

--- a/modules/users/main.tf
+++ b/modules/users/main.tf
@@ -1,9 +1,10 @@
 # USERS
 # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
+# We default to using a description of "managed by terraform" from the PagerDuty Provider rather then setting anything for the user Description
 resource "pagerduty_user" "bart" {
-  email       = "bart@foo.test"
-  name        = "Bart Simpson"
-  role        = "limited_user"
-  description = "Spikey-haired boy"
-  job_title   = "Rascal"
+  email       = var.email
+  name        = var.name
+  role        = var.role
+  job_title   = var.job_title
+  time_zone   = var.time_zone
 }

--- a/modules/users/main.tf
+++ b/modules/users/main.tf
@@ -1,0 +1,9 @@
+# USERS
+# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
+resource "pagerduty_user" "bart" {
+  email       = "bart@foo.test"
+  name        = "Bart Simpson"
+  role        = "limited_user"
+  description = "Spikey-haired boy"
+  job_title   = "Rascal"
+}

--- a/modules/users/main.tf
+++ b/modules/users/main.tf
@@ -1,7 +1,7 @@
 # USERS
 # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs/resources/user
 # We default to using a description of "managed by terraform" from the PagerDuty Provider rather then setting anything for the user Description
-resource "pagerduty_user" "bart" {
+resource "pagerduty_user" "user" {
   email       = var.email
   name        = var.name
   role        = var.role

--- a/modules/users/outputs.tf
+++ b/modules/users/outputs.tf
@@ -1,0 +1,3 @@
+output "pager_duty_id" {
+  value = pagerduty_user.user.id
+}

--- a/modules/users/providers.tf
+++ b/modules/users/providers.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     # see https://registry.terraform.io/providers/PagerDuty/pagerduty/2.7.0
     pagerduty = {
-      source  = "PagerDuty/pagerduty"
-      version = "2.7.0"
+      source  = "pagerduty/pagerduty"
+      version = "2.11.2"
     }
   }
 }

--- a/modules/users/variables.tf
+++ b/modules/users/variables.tf
@@ -22,10 +22,11 @@ variable "job_title" {
   default = "Assistant to the Regional Manager"
 }
 
+#https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 variable "time_zone" {
   type        = string
   description = "PagerDuty Users TimeZone"
-  default = "GMT"
+  default = "Europe/London"
 }
 
 

--- a/modules/users/variables.tf
+++ b/modules/users/variables.tf
@@ -15,11 +15,6 @@ variable "role" {
   default = "limited_user"
 }
 
-variable "role" {
-  type        = string
-  description = "PagerDuty Users Role"
-  default = "limited_user"
-}
 
 variable "job_title" {
   type        = string

--- a/modules/users/variables.tf
+++ b/modules/users/variables.tf
@@ -1,0 +1,36 @@
+variable "email" {
+  type        = string
+  description = "PagerDuty Users Email Address"
+}
+
+variable "name" {
+  type        = string
+  description = "PagerDuty Users Name"
+}
+
+#defaults to limited_users, can be overwritten
+variable "role" {
+  type        = string
+  description = "PagerDuty Users Role"
+  default = "limited_user"
+}
+
+variable "role" {
+  type        = string
+  description = "PagerDuty Users Role"
+  default = "limited_user"
+}
+
+variable "job_title" {
+  type        = string
+  description = "PagerDuty Users Job Title"
+  default = "Assistant to the Regional Manager"
+}
+
+variable "time_zone" {
+  type        = string
+  description = "PagerDuty Users TimeZone"
+  default = "GMT"
+}
+
+

--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,6 @@
 #
 data "local_file" "input" {
-  filename = ".creds"
+  filename = ".creds" #can be anyfile with your api key in it (don't forget to add it to the .gitignore though)
 }
 
 # see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,10 @@
+#
+data "local_file" "input" {
+  filename = ".creds"
+}
+
+# see https://registry.terraform.io/providers/PagerDuty/pagerduty/latest/docs
+provider "pagerduty" {
+  token = data.local_file.input.content #reads in your api key from a file
+  #token = "your_api_access_token" #you can use this if you want to use your API token in the providers file
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    # see https://registry.terraform.io/providers/PagerDuty/pagerduty/2.7.0
+    pagerduty = {
+      source  = "pagerduty/pagerduty"
+      version = "2.11.2"
+    }
+  }
+}
+
 #
 data "local_file" "input" {
   filename = ".creds" #can be anyfile with your api key in it (don't forget to add it to the .gitignore though)


### PR DESCRIPTION
This is the start of a rewrite of @stmcallister reference config into reusable modules that can be used by customers as well as be consumed by PD teams for testing and reference configs 